### PR TITLE
Using ghcr registry for pulling `dependabot/dependabot-core` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dependabot/dependabot-core
+FROM ghcr.io/dependabot/dependabot-core:latest
 USER root
 
 LABEL "repository"="https://github.com/marcoroth/dependabot-bump-together-action"


### PR DESCRIPTION
Use the ghcr to pull ``dependabot/dependabot-core`` image. 

See: https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-core

close #20 